### PR TITLE
fix: update DATABASE_URL in .env.example and docker-compose.yaml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@
 POSTGRES_USER=your_user
 POSTGRES_PASSWORD=your_password
 POSTGRES_DB=your_db
-DATABASE_URL=postgresql://your_user:your_password@localhost:5432/your_db?schema=public
 
 # === API ===
 BACKEND_PORT=3001

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       target: builder
     restart: always
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public
       PORT: 3000
     ports:
       - "${BACKEND_PORT}:3000"


### PR DESCRIPTION
This pull request updates the way the database connection string is managed in the environment and Docker Compose configuration. The main change is to standardize the use of individual environment variables for database credentials instead of a single connection string variable.

**Configuration improvements:**

* Removed the `DATABASE_URL` line from `.env.example`, encouraging the use of individual variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) for database configuration.
* Updated the `DATABASE_URL` in the `docker-compose.yaml` service definition to construct the connection string directly from the individual environment variables, improving clarity and consistency.