### PR TITLE
ci: gate VPS deploy behind DEPLOY_ENABLED

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -85,7 +85,11 @@ jobs:
     name: Deploy to VPS
     runs-on: ubuntu-latest
     needs: [backend, frontend]
-    if: github.ref == 'refs/heads/main'
+    # The images are always built and pushed to GHCR above. The rollout to the
+    # VPS is opt-in: set the repository variable DEPLOY_ENABLED=true once the
+    # host is provisioned for this app (VPS_HOST/VPS_USER/VPS_SSH_KEY secrets and
+    # a ~/trippier checkout). Until then the deploy is skipped so main stays green.
+    if: github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
The VPS currently hosts another app (trippier-public-API), so this repo's deploy has nowhere to land and the SSH step fails on every push to main.

Images are still built and pushed to GHCR unchanged. The deploy-to-VPS job now only runs when the repo variable `DEPLOY_ENABLED=true` is set — until then it is skipped, so main stays green.

To enable deployment later: provision the host (a `~/trippier` checkout + `.env`), make sure `VPS_HOST`/`VPS_USER`/`VPS_SSH_KEY` are valid, then set the repo variable `DEPLOY_ENABLED=true`.